### PR TITLE
feat: Added merging of album flags and removing of duplicates

### DIFF
--- a/adapters/folder/readFolder.go
+++ b/adapters/folder/readFolder.go
@@ -342,7 +342,7 @@ func (la *LocalAssetBrowser) parseDir(ctx context.Context, fsys fs.FS, dir strin
 			// Manage albums
 			if len(la.flags.ImportIntoAlbum) > 0 || len(la.flags.ImportIntoAlbums) > 0 {
 
-				albumsSet := mergeAlbumFlags(la.flags.ImportIntoAlbum, la.flags.ImportIntoAlbums)
+				albumsSet := mergeAlbumFlags(la.flags.ImportIntoAlbum, la.flags.ImportIntoAlbums) // Merged with no duplicates
 				length := len(albumsSet)
 				a.Albums = make([]assets.Album, length)
 
@@ -414,7 +414,6 @@ func mergeAlbumFlags(albumFlag []string, albumsFlag []string) []string {
 		albums[strings.TrimSpace(album)] = true
 	}
 
-	// Convert to an array.
 	albumsArray := make([]string, len(albums))
 	i := 0
 	for key := range albums {

--- a/adapters/folder/readFolder.go
+++ b/adapters/folder/readFolder.go
@@ -421,7 +421,6 @@ func mergeAlbumFlags(albumFlag []string, albumsFlag []string) []string {
 		albumsArray[i] = key
 		i++
 	}
-	fmt.Print(albumsArray)
 	return albumsArray
 }
 

--- a/adapters/folder/readFolder.go
+++ b/adapters/folder/readFolder.go
@@ -343,8 +343,7 @@ func (la *LocalAssetBrowser) parseDir(ctx context.Context, fsys fs.FS, dir strin
 			if len(la.flags.ImportIntoAlbum) > 0 || len(la.flags.ImportIntoAlbums) > 0 {
 
 				albumsSet := mergeAlbumFlags(la.flags.ImportIntoAlbum, la.flags.ImportIntoAlbums) // Merged with no duplicates
-				length := len(albumsSet)
-				a.Albums = make([]assets.Album, length)
+				a.Albums = make([]assets.Album, len(albumsSet))
 
 				for i, albumTitle := range albumsSet {
 					a.Albums[i] = assets.Album{Title: albumTitle}

--- a/adapters/folder/readFolder.go
+++ b/adapters/folder/readFolder.go
@@ -345,10 +345,9 @@ func (la *LocalAssetBrowser) parseDir(ctx context.Context, fsys fs.FS, dir strin
 				albumsSet := mergeAlbumFlags(la.flags.ImportIntoAlbum, la.flags.ImportIntoAlbums)
 				length := len(albumsSet)
 				a.Albums = make([]assets.Album, length)
-				i := 0
-				for _, albumTitle := range albumsSet {
+
+				for i, albumTitle := range albumsSet {
 					a.Albums[i] = assets.Album{Title: albumTitle}
-					i++
 				}
 			} else {
 				done := false
@@ -382,16 +381,6 @@ func (la *LocalAssetBrowser) parseDir(ctx context.Context, fsys fs.FS, dir strin
 				}
 			}
 
-			// Remove this.
-			if len(la.flags.ImportIntoAlbums) != 0 {
-				albumNames := []assets.Album{}
-				for i := 0; i < len(la.flags.ImportIntoAlbums); i++ {
-					albumNames = append(albumNames, assets.Album{Title: strings.TrimSpace(la.flags.ImportIntoAlbums[i])})
-				}
-
-				a.Albums = append(a.Albums, albumNames...)
-			}
-
 			if la.flags.SessionTag {
 				a.AddTag(la.flags.session)
 			}
@@ -419,12 +408,10 @@ func mergeAlbumFlags(albumFlag []string, albumsFlag []string) []string {
 	albums := make(map[string]bool)
 
 	for _, album := range albumFlag {
-		album = strings.TrimSpace(album)
-		albums[album] = true
+		albums[strings.TrimSpace(album)] = true
 	}
 	for _, album := range albumsFlag {
-		album = strings.TrimSpace(album)
-		albums[album] = true
+		albums[strings.TrimSpace(album)] = true
 	}
 
 	// Convert to an array.
@@ -434,6 +421,7 @@ func mergeAlbumFlags(albumFlag []string, albumsFlag []string) []string {
 		albumsArray[i] = key
 		i++
 	}
+	fmt.Print(albumsArray)
 	return albumsArray
 }
 

--- a/adapters/folder/readFolder.go
+++ b/adapters/folder/readFolder.go
@@ -342,7 +342,7 @@ func (la *LocalAssetBrowser) parseDir(ctx context.Context, fsys fs.FS, dir strin
 			// Manage albums
 			if len(la.flags.ImportIntoAlbum) > 0 || len(la.flags.ImportIntoAlbums) > 0 {
 
-				albumsSet := mergeAlbumFlags(la.flags.ImportIntoAlbum, la.flags.ImportIntoAlbums) // Merged with no duplicates
+				albumsSet := mergeAlbumFlags(la.flags.ImportIntoAlbum, la.flags.ImportIntoAlbums)
 				a.Albums = make([]assets.Album, len(albumsSet))
 
 				for i, albumTitle := range albumsSet {
@@ -403,7 +403,7 @@ func (la *LocalAssetBrowser) parseDir(ctx context.Context, fsys fs.FS, dir strin
 }
 
 func mergeAlbumFlags(albumFlag []string, albumsFlag []string) []string {
-	// Using a map to simulate a set (no duplicates)
+
 	albums := make(map[string]bool)
 
 	for _, album := range albumFlag {

--- a/adapters/folder/readFolder.go
+++ b/adapters/folder/readFolder.go
@@ -421,9 +421,11 @@ func mergeAlbumFlags(albumFlag []string, albumsFlag []string) []string {
 	albums := make(map[string]bool)
 
 	for _, album := range albumFlag {
+		album = strings.TrimSpace(album)
 		albums[album] = true
 	}
 	for _, album := range albumsFlag {
+		album = strings.TrimSpace(album)
 		albums[album] = true
 	}
 

--- a/adapters/folder/readFolder.go
+++ b/adapters/folder/readFolder.go
@@ -384,6 +384,7 @@ func (la *LocalAssetBrowser) parseDir(ctx context.Context, fsys fs.FS, dir strin
 				}
 			}
 
+			// Remove this.
 			if len(la.flags.ImportIntoAlbums) != 0 {
 				albumNames := []assets.Album{}
 				for i := 0; i < len(la.flags.ImportIntoAlbums); i++ {
@@ -413,6 +414,27 @@ func (la *LocalAssetBrowser) parseDir(ctx context.Context, fsys fs.FS, dir strin
 		}
 	}
 	return nil
+}
+
+func mergeAlbumFlags(albumFlag []string, albumsFlag []string) []string {
+	// Using a map to simulate a set (no duplicates)
+	albums := make(map[string]bool)
+
+	for _, album := range albumFlag {
+		albums[album] = true
+	}
+	for _, album := range albumsFlag {
+		albums[album] = true
+	}
+
+	// Convert to an array.
+	albumsArray := make([]string, len(albums))
+	i := 0
+	for key := range albums {
+		albumsArray[i] = key
+		i++
+	}
+	return albumsArray
 }
 
 func checkExistSideCar(fsys fs.FS, name string, ext string) (string, error) {

--- a/adapters/folder/readFolder.go
+++ b/adapters/folder/readFolder.go
@@ -341,15 +341,13 @@ func (la *LocalAssetBrowser) parseDir(ctx context.Context, fsys fs.FS, dir strin
 
 			// Manage albums
 			if len(la.flags.ImportIntoAlbum) > 0 || len(la.flags.ImportIntoAlbums) > 0 {
-				length := len(la.flags.ImportIntoAlbum) + len(la.flags.ImportIntoAlbums)
+
+				albumsSet := mergeAlbumFlags(la.flags.ImportIntoAlbum, la.flags.ImportIntoAlbums)
+				length := len(albumsSet)
 				a.Albums = make([]assets.Album, length)
 				i := 0
-				for _, albumTitle := range la.flags.ImportIntoAlbum {
-					a.Albums[i] = assets.Album{Title: strings.TrimSpace(albumTitle)}
-					i++
-				}
-				for _, albumTitle := range la.flags.ImportIntoAlbums {
-					a.Albums[i] = assets.Album{Title: strings.TrimSpace(albumTitle)}
+				for _, albumTitle := range albumsSet {
+					a.Albums[i] = assets.Album{Title: albumTitle}
 					i++
 				}
 			} else {


### PR DESCRIPTION
- Added a new function, mergeAlbumFlags. 
- Merges, trims and removes duplicates from the album names of the 2 import flags. 
- Implemented function in parseDir. 
- Small updates to code in parseDir for better readability. 

Closes #26