### PR TITLE
feat: Added test for combination of album flags

### DIFF
--- a/adapters/folder/readFolder_test.go
+++ b/adapters/folder/readFolder_test.go
@@ -865,6 +865,85 @@ func TestParseDir_DuplicateAlbums(t *testing.T) {
 	}
 }
 
+func TestParseDir_CombiningAlbumFlags(t *testing.T) {
+	t0 := time.Date(2021, 1, 1, 0, 0, 0, 0, time.Local)
+	ic := filenames.NewInfoCollector(time.Local, filetypes.DefaultSupportedMedia)
+	ctx := context.Background()
+	logFile := configuration.DefaultLogFile()
+	log := app.Log{
+		File:  logFile,
+		Level: "INFO",
+	}
+	err := log.OpenLogFile()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	recorder := fileevent.NewRecorder(log.Logger)
+
+	gOut := make(chan *assets.Group)
+	var receivedGroups []*assets.Group
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for group := range gOut {
+			receivedGroups = append(receivedGroups, group)
+		}
+	}()
+
+	fsys := newInMemFS("MemFS", ic).
+		addFile("root_01.jpg", t0).
+		addFile("photos/photo_01.jpg", t0).
+		addFile("photos/photo_01.json", t0).
+		addFile("photos/summer/photo_02.jpg", t0)
+
+	flags := &ImportFolderOptions{
+		UsePathAsAlbumName: FolderModeNone,
+		InfoCollector:      ic,
+		SupportedMedia:     filetypes.DefaultSupportedMedia,
+		ImportIntoAlbum:    []string{"album1"},
+		ImportIntoAlbums:   []string{"albums1"},
+	}
+	la, err := NewLocalFiles(ctx, recorder, flags, fsys)
+	if err != nil {
+		t.Errorf("Error, %v", err)
+		return
+	}
+
+	err = la.parseDir(ctx, fsys, "photos", gOut)
+
+	close(gOut)
+	wg.Wait()
+
+	found_albumFlag := false
+	found_albumsFlag := false
+	for _, group := range receivedGroups {
+		for _, asset := range group.Assets {
+			for _, album := range asset.Albums {
+				if album.Title == "album1" {
+					found_albumFlag = true
+				}
+				if album.Title == "albums1" {
+					found_albumsFlag = true
+				}
+			}
+		}
+	}
+
+	if !found_albumFlag {
+		t.Errorf("Expected an asset with album 'album1' from ImportIntAlbum, recieved none.")
+	}
+	if !found_albumsFlag {
+		t.Errorf("Expected an asset with album 'albums1' from ImportIntoAlbums, recieved none.")
+	}
+
+	if err != nil {
+		t.Errorf("Error, %v", err)
+	}
+}
+
 func TestNewLocalFiles_ConflictingAlbumFlags(t *testing.T) {
 	ctx := context.Background()
 	recorder := &fileevent.Recorder{}


### PR DESCRIPTION
Added a test that checks the functionality in using both ImportIntoAlbums and ImportIntoAlbum flags for the same asset. 

Basically copied and pasted a previous test and tweaked it a little. A concern is that there is too much copy and paste overall in the test-file, not just my test. Shouldn't all of these tests be combined and looped through like in previously written tests to avoid code repetition? 